### PR TITLE
feat: add address selection at checkout page

### DIFF
--- a/apps/next-app/src/app/api/(CustomerAPI)/user/orders/route.ts
+++ b/apps/next-app/src/app/api/(CustomerAPI)/user/orders/route.ts
@@ -16,7 +16,7 @@ export async function POST(req:NextRequest) {
             return error
         }
         const body = await req.json()
-        const totalAmount = body.totalAmount
+        const {totalAmount, deliveryAddress} = body
         const options = {
             amount: Math.round(Number((+totalAmount).toFixed(2)) * 100),
             currency: "INR",
@@ -33,7 +33,8 @@ export async function POST(req:NextRequest) {
                         orderStatus: "Pending", 
                         paymentStatus: "Pending",
                         customerId: userId,
-                        razorpayOrderId: paymentResponse.id
+                        razorpayOrderId: paymentResponse.id,
+                        deliveryAddress: deliveryAddress,
                     }
                 })
             })

--- a/apps/next-app/src/components/Dashboard/Customer/core/AddressSection/AddressModal.tsx
+++ b/apps/next-app/src/components/Dashboard/Customer/core/AddressSection/AddressModal.tsx
@@ -15,6 +15,8 @@ import { AddressType } from '@/types';
 import axios from 'axios';
 import { toast } from 'sonner';
 import { Loader } from 'lucide-react';
+import { useDispatch } from 'react-redux';
+import { addAddress } from '@/redux/slices/profileSlice';
 
 interface AddressModalProps {
   open: boolean;
@@ -47,6 +49,7 @@ export function AddressModal({
   }, [editingAddress, reset]);
 
   const [isSaving, setIsSaving] = useState(false)
+  const dispatch = useDispatch()
   
   const onsubmit = async (data: AddressType) => {
     setIsSaving(true)
@@ -64,6 +67,7 @@ export function AddressModal({
       const response = await axios.post('/api/user/profile/address', data)
       if(response.data?.success){
         onAddressAdded?.(data)
+        dispatch(addAddress(data))
         toast.success("Address Added Successfully")
       }else{
         toast.error("Cannot add Address")

--- a/apps/next-app/src/components/Dashboard/Customer/core/AddressSection/AddressSection.tsx
+++ b/apps/next-app/src/components/Dashboard/Customer/core/AddressSection/AddressSection.tsx
@@ -19,6 +19,8 @@ import { AddressModal } from './AddressModal';
 import { toast } from 'sonner';
 import axios from 'axios';
 import { AddressType } from '@/types';
+import { useDispatch } from 'react-redux';
+import { removeAddress, updateAddress } from '@/redux/slices/profileSlice';
 
 export function AddressSection({initialAddresses} : {initialAddresses: AddressType[]}) {
 
@@ -27,6 +29,7 @@ export function AddressSection({initialAddresses} : {initialAddresses: AddressTy
   const [editingAddress, setEditingAddress] = useState<AddressType | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false)
+  const dispatch = useDispatch()
 
   useEffect(() => {
     if (initialAddresses?.length) {
@@ -40,8 +43,9 @@ export function AddressSection({initialAddresses} : {initialAddresses: AddressTy
     try{
       const response = await axios.delete('/api/user/profile/address', { data: { id: deleteId } });
       if(response.data?.success){
-        toast.success('Address deleted successfully');
+        dispatch(removeAddress(deleteId))
         setAddresses((prev) => prev.filter((addr) => addr.id !== deleteId));
+        toast.success('Address deleted successfully');
       }
     }catch(error){
       console.log("Something went wrong while deleting address", error);
@@ -63,6 +67,7 @@ export function AddressSection({initialAddresses} : {initialAddresses: AddressTy
 
   const handleAddressEdit = (updatedAddress: AddressType) => {
     setAddresses((prev) => prev.map(addr => addr.id === updatedAddress.id ? updatedAddress : addr))
+    dispatch(updateAddress(updatedAddress))
     setEditingAddress(null);
   }
 

--- a/apps/next-app/src/components/core/AddressSelector.tsx
+++ b/apps/next-app/src/components/core/AddressSelector.tsx
@@ -5,67 +5,39 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
 import { AddressType } from '@/types';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/reducer';
+import Link from 'next/link';
+import { DeliveryAddressType } from '@/app/(landing)/cart/page';
 
-export function AddressSelector() {
-  const [addresses] = useState<AddressType[]>([]);
-  const [selectedAddressId, setSelectedAddressId] = useState<string | null>(null);
+interface AddressSelectorProps {
+  onSelect: (address: DeliveryAddressType) => void;
+  selectedAddress: DeliveryAddressType | null;
+}
+export function AddressSelector({onSelect, selectedAddress}: AddressSelectorProps) {
+  const profile = useSelector((state: RootState) => state.profile.profile);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  // const [setIsFormOpen] = useState(false);
-  // const [editingAddress, setEditingAddress] = useState<AddressType | null>(null);
   const [loading] = useState(false);
+  const [selectedAddressId, setSelectedAddressId] = useState<string | null>(null)
 
-//   useEffect(() => {
-//     loadAddresses();
-//   }, []);
-
-//   const loadAddresses = async () => {
-//     try {
-//       const { data: { user } } = await supabase.auth.getUser();
-
-//       if (!user) {
-//         setLoading(false);
-//         return;
-//       }
-
-//       const { data, error } = await supabase
-//         .from('addresses')
-//         .select('*')
-//         .eq('user_id', user.id)
-//         .order('is_default', { ascending: false })
-//         .order('created_at', { ascending: false });
-
-//       if (error) throw error;
-
-//       setAddresses(data || []);
-
-//       //@ts-ignore
-//       const defaultAddress = data?.find(addr => addr.is_default);
-//       if (defaultAddress) {
-//         setSelectedAddressId(defaultAddress.id);
-//       } else if (data && data.length > 0) {
-//         setSelectedAddressId(data[0].id);
-//       }
-//     } catch (error) {
-//       console.error('Error loading addresses:', error);
-//       toast.error('Failed to load addresses')
-//     } finally {
-//       setLoading(false);
-//     }
-//   };
-
-//   const handleFormClose = () => {
-//     setIsFormOpen(false);
-//     setEditingAddress(null);
-//     loadAddresses();
-//   };
-
-  const handleSelectAddress = (addressId: string) => {
-    setSelectedAddressId(addressId);
-    setIsDrawerOpen(false);
+  const handleSelectAddress = (address: AddressType) => {
+    setSelectedAddressId(address.id)
+    const deliveryAddress = {
+      fullName: address.fullName,
+      phone: address.phone,
+      street: address.street,
+      city: address.city,
+      state: address.state,
+      postalCode: address.postalCode,
+      country: address.postalCode,
+    }
+    console.log("Delivery Address: ", deliveryAddress)
+    if(deliveryAddress){
+      onSelect(deliveryAddress)
+      setIsDrawerOpen(false);
+    }
   };
-
-  const selectedAddress = addresses.find(addr => addr.id === selectedAddressId);
-
+  
   if (loading) {
     return (
       <Card className="p-4 border-orange-200">
@@ -115,30 +87,30 @@ export function AddressSelector() {
                 <MapPin className="w-5 h-5 text-orange-600" />
                 Select Delivery Address
               </DrawerTitle>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  setIsDrawerOpen(false);
-                  // setIsFormOpen(true);
-                }}
-                className="gap-2 text-orange-600 hover:text-orange-700 hover:bg-orange-50"
-              >
-                <Plus className="w-4 h-4" />
-                Add New
-              </Button>
+              <Link href={'/user/profile'}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setIsDrawerOpen(false);
+                  }}
+                  className="gap-2 text-orange-600 hover:text-orange-700 hover:bg-orange-50"
+                >
+                  <Plus className="w-4 h-4" />
+                  Add New
+                </Button>
+              </Link>
             </div>
           </DrawerHeader>
 
           <div className="overflow-y-auto p-4">
-            {addresses.length === 0 ? (
+            {profile?.addresses.length === 0  ? (
               <div className="text-center py-12">
                 <MapPin className="w-16 h-16 mx-auto mb-4 text-orange-300" />
                 <p className="text-gray-600 mb-4">No addresses saved yet</p>
                 <Button
                   onClick={() => {
                     setIsDrawerOpen(false);
-                    // setIsFormOpen(true);
                   }}
                   className="gap-2 bg-orange-600 hover:bg-orange-700"
                 >
@@ -147,9 +119,9 @@ export function AddressSelector() {
                 </Button>
               </div>
             ) : (
-              <div className="space-y-3">
+              <div className="space-y-3 grid grid-cols-2 lg:grid-cols-4 space-x-2">
                 <AnimatePresence mode="popLayout">
-                  {addresses.map((address) => (
+                  {profile?.addresses?.map((address: AddressType) => (
                     <motion.div
                       key={address.id}
                       initial={{ opacity: 0, y: 20 }}
@@ -163,7 +135,7 @@ export function AddressSelector() {
                             ? 'border-orange-500 bg-orange-50 shadow-md ring-2 ring-orange-500'
                             : 'border-gray-200 hover:border-orange-300 hover:bg-orange-50/30'
                         }`}
-                        onClick={() => handleSelectAddress(address.id)}
+                        onClick={() => handleSelectAddress(address)}
                       >
                         <div className="flex items-start gap-3">
                           <motion.div
@@ -203,8 +175,7 @@ export function AddressSelector() {
                             </p>
 
                             <p className="text-sm text-gray-700">
-                              {address.phone}
-                              {address.street && `, ${address.street}`}
+                              {address.street && `${address.street}`}
                             </p>
 
                             <p className="text-sm text-gray-700">
@@ -226,12 +197,6 @@ export function AddressSelector() {
           </div>
         </DrawerContent>
       </Drawer>
-
-      {/* <AddressForm
-        open={isFormOpen}
-        onClose={handleFormClose}
-        editingAddress={editingAddress}
-      /> */}
     </>
   );
 }

--- a/apps/next-app/src/redux/slices/profileSlice.ts
+++ b/apps/next-app/src/redux/slices/profileSlice.ts
@@ -19,7 +19,7 @@ export interface ProfileType {
   email: string
   store?: string
   createdAt: string
-  addresses?: Address[] 
+  addresses: Address[]
   role: "SELLER" | "CUSTOMER"
 }
 
@@ -48,9 +48,23 @@ const profileSlice = createSlice({
     setLoading(state, action: PayloadAction<boolean>) {
       state.loading = action.payload;
     },
+    addAddress(state, action){
+      if (!state.profile || !state.profile.addresses) return;
+      state.profile.addresses.unshift(action.payload)
+    },
+    updateAddress(state, action){
+      if (!state.profile || !state.profile.addresses) return;
+      state.profile.addresses = state.profile.addresses.map(addr =>
+        addr.id === action.payload.id ? action.payload : addr
+      )
+    },
+    removeAddress(state, action){
+      if (!state.profile || !state.profile.addresses) return;
+      state.profile.addresses = state.profile.addresses.filter(addr => addr.id !== action.payload)
+    }
   },
 })
 
-export const { setProfile, setLoading, hydrateProfile } = profileSlice.actions
+export const { setProfile, setLoading, hydrateProfile, addAddress, updateAddress, removeAddress } = profileSlice.actions
 
 export default profileSlice.reducer

--- a/packages/database/prisma/migrations/20251027043308_added_delivery_address_to_order_table/migration.sql
+++ b/packages/database/prisma/migrations/20251027043308_added_delivery_address_to_order_table/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `deliveryAddressId` to the `Order` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Order" ADD COLUMN     "deliveryAddressId" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Order" ADD CONSTRAINT "Order_deliveryAddressId_fkey" FOREIGN KEY ("deliveryAddressId") REFERENCES "BillingAddress"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20251027084052_updated_order_table/migration.sql
+++ b/packages/database/prisma/migrations/20251027084052_updated_order_table/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `deliveryAddressId` on the `Order` table. All the data in the column will be lost.
+  - Added the required column `deliveryAddress` to the `Order` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Order" DROP CONSTRAINT "Order_deliveryAddressId_fkey";
+
+-- AlterTable
+ALTER TABLE "Order" DROP COLUMN "deliveryAddressId",
+ADD COLUMN     "deliveryAddress" JSONB NOT NULL;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -91,11 +91,13 @@ model Order{
   paymentStatus     PaymentStatus    @default(Pending)
   placedOn          DateTime         @default(now())
   customerId        String
+  deliveryAddress   Json
   razorpayOrderId   String           @unique
   razorpayPaymentId String?
-  customer          Customer          @relation(fields: [customerId], references: [id])
+  customer          Customer         @relation(fields: [customerId], references: [id])
   items             OrderItem[]
 }
+
 model OrderItem {
   id          Int         @id @default(autoincrement())
   orderId     String
@@ -109,8 +111,6 @@ model OrderItem {
   item        Item        @relation(fields: [itemId], references: [id])
   seller      Seller      @relation(fields: [sellerId], references: [id])
 }
-  // customerId  String
-  // customer    Customer  @relation((fields: [customerId], references: [id]))
 
 model Customer{
   id        String    @id @default(uuid())


### PR DESCRIPTION
# 🚀 Feature: Address Selection at Checkout

### 🧾 Related Issue
Closes #26

---

### 📋 Description
This PR introduces the **Address Selection** feature during the checkout process in the Zivelle app.  
Users can now choose a delivery address before placing an order. The selected address is sent along with the order details to the backend for processing and order record creation.

---

### 💡 Key Highlights
- Added address selection UI on the **Checkout Page**.  
- Integrated selected address with the order creation API (`/api/user/orders`).  
- Implemented frontend validation to ensure users select an address before proceeding with checkout.  
- Updated backend request payload to include the `deliveryAddress` snapshot.  
- Improved Redux slice with:
  - `updateAddress` reducer → for updating user addresses.
  - `removeAddress` reducer → for deleting an address safely.
  -  `addAddress` reducder → for adding a new address

---

### 🧠 Implementation Details
- **Frontend:**  
  - Added `AddressSelector` component with address cards and selection logic.  
  - Added proper state validation to prevent checkout without a selected address.
  
- **Backend:**  
  - Updated order schema and API to store full delivery address snapshot (`Json` type).  
  - Ensures historical accuracy even if user deletes the address later.

